### PR TITLE
Removing comments from source file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+
+
+
+.PHONY: build
+build:
+	go build -o ./bin/grpc-go-redact .
+
+.PHONY: test
+test: build
+	./bin/grpc-go-redact -input ./test/test.pb.go -output ./bin/output.go

--- a/generate.go
+++ b/generate.go
@@ -27,7 +27,7 @@ func getGenParseInfo() (*ParseInfo, error) {
 	}
 
 	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, stringFuncGenFileName, stringFuncGenFile, parser.ParseComments)
+	f, err := parser.ParseFile(fset, stringFuncGenFileName, stringFuncGenFile, parser.AllErrors)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,6 @@ func getStringFuncASTNode(genParseInfo *ParseInfo) (*ast.FuncDecl, error) {
 		}
 		if funcDecal.Name.String() == stringFuncMethodName {
 			stringFuncNode = funcDecal
-			return false
 		}
 
 		return true

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func main(){
 	}
 
 	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, inputFile, nil, parser.ParseComments)
+	f, err := parser.ParseFile(fset, inputFile, nil, parser.AllErrors)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Fixes #1 

Removing comments when parsing the target and genstring file to fix the issue of comments not being parsed as single func ast node breaking indentiion. 