### PR TITLE
return "null" when x is nil

### DIFF
--- a/generator/internal/stringfunc.go
+++ b/generator/internal/stringfunc.go
@@ -21,7 +21,12 @@ type M struct {
 }
 
 func (x *M) String() string {
-	switch x := interface{}(x).(type) {
+	i := interface{}(x)
+	if i == nil {
+		return "null"
+	}
+
+	switch x := i.(type) {
 	case protoreflect.Enum:
 		return protoimpl.X.EnumStringOf(x.Descriptor(), x.Number())
 


### PR DESCRIPTION
Make the String func return `"null"` when the object is nil. Previously it was panicking: `panic: reflect: call of reflect.Value.Type on zero Value`.