### PR TITLE
return "{}" when x is nil

### DIFF
--- a/generator/internal/stringfunc.go
+++ b/generator/internal/stringfunc.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"encoding/json"
+	"reflect"
 
 	"github.com/Azure/redact"
 	"google.golang.org/protobuf/proto"
@@ -22,8 +23,10 @@ type M struct {
 
 func (x *M) String() string {
 	i := interface{}(x)
-	if i == nil {
-		return "null"
+
+	v := reflect.ValueOf(i)
+	if v.Kind() == reflect.Pointer && v.IsNil() {
+		return "{}"
 	}
 
 	switch x := i.(type) {

--- a/test/output.pb_test.go
+++ b/test/output.pb_test.go
@@ -116,3 +116,38 @@ func TestReadAndWrite(t *testing.T) {
 		assert.Equal(t, baseBytes, writenBytes)
 	})
 }
+
+func TestNil(t *testing.T) {
+	t.Run("Nil protoreflect.Enum", func(t *testing.T) {
+		var e *E
+
+		defer func() {
+			r := recover()
+			assert.NotNil(t, r)
+		}()
+
+		_ = e.String()
+		assert.Fail(t, "it should have panicked")
+	})
+
+	t.Run("Zero protoreflect.Enum", func(t *testing.T) {
+		var e E
+
+		s := e.String()
+		assert.NotEqual(t, "{}", s)
+	})
+
+	t.Run("Nil protoreflect.ProtoMessage", func(t *testing.T) {
+		var m *M
+
+		s := m.String()
+		assert.Equal(t, "{}", s)
+	})
+
+	t.Run("Zero protoreflect.ProtoMessage", func(t *testing.T) {
+		var m M
+
+		s := m.String()
+		assert.NotEqual(t, "{}", s)
+	})
+}


### PR DESCRIPTION
Make the String func return "{}" when the receiver is null. This restores the original behaviour of the function, before proto.Clone was used to deep-copy objects.